### PR TITLE
Add support for tagged terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*~
+
 # OSX
 .DS_Store
 *~.nib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - "node"
+  - "4.2"
+  - "0.12"

--- a/README.md
+++ b/README.md
@@ -2,18 +2,27 @@
 
 [![Build Status](https://travis-ci.org/tatsuyaoiw/search-text-tokenizer.svg?branch=master)](https://travis-ci.org/tatsuyaoiw/search-text-tokenizer)
 
-Tokenize a search keyword text in the same manner as Google does.
+A search query tokeniser inspired by Google.
 
-- Split space-delimitered keyword string into an array of keywords
-- Treat dobule-quoted keywords as phrase
+- Split a space-delimitered query string into an array of terms
+- Treat quoted terms as phrases
+- Support tagged terms (tag:term)
 
-## Example
+## Examples
 
 ```js
-var tokenizer = require('search-text-tokenizer');
+var tokenizer = require( 'search-text-tokenizer' );
 
-console.log(tokenizer('red bull'));  // ['red', 'bull']
-console.log(tokenizer('"red bull" "gives you wings"'));  // ['"red bull"', '"gives you wings"']
+console.log( tokenizer( 'red bull' ) );
+// [ 'red', 'bull' ]
+
+var result = console.log( tokenizer( '"red bull" "gives you wings"' ) );
+// [ 'red bull', 'gives you wings' ]
+// result[0].phrase === true
+
+result = console.log( tokenizer( 'author:tolkien' ) );
+// [ 'tolkien' ]
+// result[0].tag === 'author'
 ```
 
 ## Installation
@@ -24,18 +33,13 @@ $ npm install search-text-tokenizer
 
 ## Running test
 
-To run the test suite first invoke the following command in the project directory.
+To run the test suite first invoke the following commands in the project directory.
 
 ```
 $ npm install
-```
-
-then run the tests:
-
-```
 $ npm test
 ```
 
 ## License
 
-MIT © Tatsuya Oiwa
+MIT © Tatsuya Oiwa, Dannii Willis

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -13,32 +13,33 @@ function tokenize( input )
 	while ( matched = pattern.exec( input ) )
 	{
 		var tag = matched[1],
-		term = matched[2];
+		term = matched[2],
+		result;
 		
 		// Remove quotes
 		if ( /^".+"$/.test( term ) )
 		{
-			term = _.trim( term, '"' );
+			term = _.trim( term, '" ' );
 		}
 		if ( /^'.+'$/.test( term ) )
 		{
-			term = _.trim( term, "'" );
+			term = _.trim( term, "' " );
 		}
 		
-		// Box up terms in a String object
-		term = new String( term );
+		// Box up terms in a object
+		result = { term: term };
 		
 		// Mark phrases
 		if ( /\s/.test( term ) )
 		{
-			term.phrase = true;
+			result.phrase = true;
 		}
 		if ( tag )
 		{
-			term.tag = tag.slice( 0, -1 );
+			result.tag = tag.slice( 0, -1 );
 		}
 		
-		results.push( term );
+		results.push( result );
 	}
 	
 	return results;

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -14,26 +14,22 @@ function tokenize( input )
 	{
 		var tag = matched[1],
 		term = matched[2],
-		result;
+		result = {};
 		
 		// Remove quotes
 		if ( /^".+"$/.test( term ) )
 		{
 			term = _.trim( term, '" ' );
+			result.phrase = true;
 		}
 		if ( /^'.+'$/.test( term ) )
 		{
 			term = _.trim( term, "' " );
-		}
-		
-		// Box up terms in a object
-		result = { term: term };
-		
-		// Mark phrases
-		if ( /\s/.test( term ) )
-		{
 			result.phrase = true;
 		}
+		
+		result.term = term;
+		
 		if ( tag )
 		{
 			result.tag = tag.slice( 0, -1 );

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -1,3 +1,25 @@
-module.exports = function(str){
-  return str.match(/"[^"]*"|'[^']*'|[^\s]+/g) || [''];
+var _ = require( 'lodash' );
+
+function tokenize( input )
+{
+	// Trim input
+	input = _.trim( input );
+
+	var results = input.match(/"[^"]*"|'[^']*'|[^\s]+/g) || [''];
+	results = _( results ).map( function( term )
+	{
+		// Remove quotes
+		if ( /^".+"$/.test( term ) )
+		{
+			term = _.trim( term, '"' );
+		}
+		if ( /^'.+'$/.test( term ) )
+		{
+			term = _.trim( term, "'" );
+		}
+		return term;
+	}).value();
+	return results;
 }
+
+module.exports = tokenize;

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -2,10 +2,11 @@ var _ = require( 'lodash' );
 
 function tokenize( input )
 {
+
 	// Trim input
 	input = _.trim( input );
 
-	var results = input.match(/"[^"]*"|'[^']*'|[^\s]+/g) || [''];
+	var results = input.match( /"[^"]*"|'[^']*'|[^\s]+/g ) || [''];
 	results = _( results ).map( function( term )
 	{
 		// Remove quotes
@@ -17,9 +18,19 @@ function tokenize( input )
 		{
 			term = _.trim( term, "'" );
 		}
+		
+		// Box up terms in a String object
+		term = new String( term );
+		
+		// Mark phrases
+		if ( /\s/.test( term ) )
+		{
+			term.phrase = true;
+		}
+		
 		return term;
-	}).value();
-	return results;
+	});
+	return results.value();
 }
 
 module.exports = tokenize;

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -5,10 +5,16 @@ function tokenize( input )
 
 	// Trim input
 	input = _.trim( input );
-
-	var results = input.match( /"[^"]*"|'[^']*'|[^\s]+/g ) || [''];
-	results = _( results ).map( function( term )
+	
+	var pattern = /(\w+:)?("[^"]*"|'[^']*'|[^\s]+)/g,
+	results = [],
+	matched;
+	
+	while ( matched = pattern.exec( input ) )
 	{
+		var tag = matched[1],
+		term = matched[2];
+		
 		// Remove quotes
 		if ( /^".+"$/.test( term ) )
 		{
@@ -27,10 +33,15 @@ function tokenize( input )
 		{
 			term.phrase = true;
 		}
+		if ( tag )
+		{
+			term.tag = tag.slice( 0, -1 );
+		}
 		
-		return term;
-	});
-	return results.value();
+		results.push( term );
+	}
+	
+	return results;
 }
 
 module.exports = tokenize;

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -1,3 +1,3 @@
 module.exports = function(str){
-  return str.match(/"[^"]*"|[^\s]+/g) || '';
+  return str.match(/"[^"]*"|'[^']*'|[^\s]+/g) || [''];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-text-tokenizer",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A tokenizer for Google-like search queries",
   "main": "index",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,8 @@
   "scripts": {
     "test": "make test"
   },
-  "repository": {
-    "type" : "git",
-    "url" : "http://github.com/tatsuyaoiw/search-text-tokenizer.git"
-  },
+  "repository": "tatsuyaoiw/search-text-tokenizer",
+  "bugs": "https://github.com/tatsuyaoiw/search-text-tokenizer/issues",
   "author": "Tatsuya Oiwa <tatsuyaoiw@gmail.com>",
   "license": "MIT",
   "keywords": [
@@ -22,5 +20,8 @@
     "text",
     "query",
     "keyword"
-  ]
+  ],
+  "dependencies": {
+    "lodash": "^3.10.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "search-text-tokenizer",
   "version": "1.0.0",
-  "description": "A tokenizer for Google-like search text",
+  "description": "A tokenizer for Google-like search queries",
   "main": "index",
+  "dependencies": {
+    "lodash": "^3.10.0"
+  },
   "devDependencies": {
     "mocha": "*",
     "should": "*"
@@ -20,8 +23,5 @@
     "text",
     "query",
     "keyword"
-  ],
-  "dependencies": {
-    "lodash": "^3.10.0"
-  }
+  ]
 }

--- a/test/test.tokenizer.js
+++ b/test/test.tokenizer.js
@@ -27,6 +27,12 @@ describe( 'tokenizer', function()
 				phrase: true,
 			} ] );
 		
+		tokenizer( '"redbull"' )
+			.should.eql( [ {
+				term: 'redbull',
+				phrase: true,
+			} ] );
+		
 		tokenizer( "'red bull'" )
 			.should.eql( [ {
 				term: 'red bull',

--- a/test/test.tokenizer.js
+++ b/test/test.tokenizer.js
@@ -2,29 +2,44 @@ var tokenizer = require('../lib/tokenizer')
   , should = require('should');
 
 describe('tokenizer', function(){
-  it('should support single word', function(){
-    tokenizer('redbull').should.eql(['redbull']);
+  it('should support single word inputs', function(){
+    tokenizer('redbull')
+      .should.eql(['redbull']);
   });
 
   it('should support multiple words', function(){
-    tokenizer('red bull').should.eql(['red', 'bull']);
+    tokenizer('red bull')
+      .should.eql(['red', 'bull']);
   });
 
-  it('should ignore empty query', function(){
-    tokenizer('').should.eql('');
+  it('should ignore empty queries', function(){
+    tokenizer('')
+      .should.eql(['']);
   });
 
-  it('should ignore space', function(){
-    tokenizer(' ').should.eql('');
+  it('should ignore spaces', function(){
+    tokenizer(' ')
+      .should.eql(['']);
   });
 
   it('should trim spaces', function(){
-    tokenizer(' redbull ').should.eql(['redbull']);
+    tokenizer(' redbull ')
+      .should.eql(['redbull']);
   });
 
-  it('should support phrase', function(){
+  it('should support double quoted phrases', function(){
     tokenizer('"red bull"')
       .should.eql(['"red bull"']);
+  });
+
+  it('should support single quoted phrases', function(){
+    tokenizer("'red bull'")
+      .should.eql(["'red bull'"]);
+  });
+
+  it('should not interpret apostrophes as single quoted phrases', function(){
+    tokenizer("don't won't")
+      .should.eql(["don't", "won't"]);
   });
 
   it('should support multiple phrases', function(){
@@ -32,17 +47,17 @@ describe('tokenizer', function(){
       .should.eql(['"red bull"', '"gives you wings"']);
   });
 
-  it('should support pair of word and phrase', function(){
+  it('should support a single words and phrases', function(){
     tokenizer('red bull "gives you wings"')
       .should.eql(['red', 'bull', '"gives you wings"']);
   });
 
-  it('should support broken phrase', function(){
+  it('should support broken phrases', function(){
     tokenizer('red bull "gives you wings')
       .should.eql(['red', 'bull', '"gives', 'you', 'wings']);
   });
 
-  it('should support broken phrase 2', function(){
+  it('should support broken phrases (2)', function(){
     tokenizer('red bull gives you wings"')
       .should.eql(['red', 'bull', 'gives', 'you', 'wings"']);
   });

--- a/test/test.tokenizer.js
+++ b/test/test.tokenizer.js
@@ -25,9 +25,9 @@ describe( 'tokenizer', function()
 	
 	it( 'should handle empty queries', function() {
 		tokenizer( '' )
-			.should.jsonEql( [''] );
+			.should.jsonEql( [] );
 		tokenizer( ' ' )
-			.should.jsonEql( [''] );
+			.should.jsonEql( [] );
 	});
 	
 	it( 'should trim spaces', function() {
@@ -65,5 +65,23 @@ describe( 'tokenizer', function()
 			.should.jsonEql( ['red', 'bull', '"gives', 'you', 'wings'] );
 		tokenizer( 'red bull gives you wings"' )
 			.should.jsonEql( ['red', 'bull', 'gives', 'you', 'wings"'] );
+	});
+	
+	it( 'should support tagged words', function() {
+		var result = tokenizer( 'author:tolkien' );
+		result.should.jsonEql( ['tolkien'] );
+		result[0].tag.should.eql( 'author' );
+	});
+	
+	it( 'should support tagged phrases', function() {
+		var result = tokenizer( 'author:"j. r. r. tolkien"' );
+		result.should.jsonEql( ['j. r. r. tolkien'] );
+		result[0].tag.should.eql( 'author' );
+		result[0].phrase.should.eql( true );
+		
+		result = tokenizer( "author:'j. r. r. tolkien'" );
+		result.should.jsonEql( ['j. r. r. tolkien'] );
+		result[0].tag.should.eql( 'author' );
+		result[0].phrase.should.eql( true );
 	});
 });

--- a/test/test.tokenizer.js
+++ b/test/test.tokenizer.js
@@ -29,12 +29,12 @@ describe('tokenizer', function(){
 
   it('should support double quoted phrases', function(){
     tokenizer('"red bull"')
-      .should.eql(['"red bull"']);
+      .should.eql(['red bull']);
   });
 
   it('should support single quoted phrases', function(){
     tokenizer("'red bull'")
-      .should.eql(["'red bull'"]);
+      .should.eql(['red bull']);
   });
 
   it('should not interpret apostrophes as single quoted phrases', function(){
@@ -44,12 +44,12 @@ describe('tokenizer', function(){
 
   it('should support multiple phrases', function(){
     tokenizer('"red bull" "gives you wings"')
-      .should.eql(['"red bull"', '"gives you wings"']);
+      .should.eql(['red bull', 'gives you wings']);
   });
 
-  it('should support a single words and phrases', function(){
+  it('should support single words and phrases', function(){
     tokenizer('red bull "gives you wings"')
-      .should.eql(['red', 'bull', '"gives you wings"']);
+      .should.eql(['red', 'bull', 'gives you wings']);
   });
 
   it('should support broken phrases', function(){

--- a/test/test.tokenizer.js
+++ b/test/test.tokenizer.js
@@ -1,64 +1,69 @@
-var tokenizer = require('../lib/tokenizer')
-  , should = require('should');
+var _ = require( 'lodash' );
+var should = require( 'should' );
+var tokenizer = require( '../lib/tokenizer' );
 
-describe('tokenizer', function(){
-  it('should support single word inputs', function(){
-    tokenizer('redbull')
-      .should.eql(['redbull']);
-  });
+should.Assertion.add( 'jsonEql', function( val )
+{
+	this.params = { operator: 'to be JSON eql' };
+	var actual = JSON.stringify( this.obj );
+	var expected = JSON.stringify( val );
+	this.params.details = actual + ' != ' + expected;
+	this.assert( actual == expected );
+});
 
-  it('should support multiple words', function(){
-    tokenizer('red bull')
-      .should.eql(['red', 'bull']);
-  });
-
-  it('should ignore empty queries', function(){
-    tokenizer('')
-      .should.eql(['']);
-  });
-
-  it('should ignore spaces', function(){
-    tokenizer(' ')
-      .should.eql(['']);
-  });
-
-  it('should trim spaces', function(){
-    tokenizer(' redbull ')
-      .should.eql(['redbull']);
-  });
-
-  it('should support double quoted phrases', function(){
-    tokenizer('"red bull"')
-      .should.eql(['red bull']);
-  });
-
-  it('should support single quoted phrases', function(){
-    tokenizer("'red bull'")
-      .should.eql(['red bull']);
-  });
-
-  it('should not interpret apostrophes as single quoted phrases', function(){
-    tokenizer("don't won't")
-      .should.eql(["don't", "won't"]);
-  });
-
-  it('should support multiple phrases', function(){
-    tokenizer('"red bull" "gives you wings"')
-      .should.eql(['red bull', 'gives you wings']);
-  });
-
-  it('should support single words and phrases', function(){
-    tokenizer('red bull "gives you wings"')
-      .should.eql(['red', 'bull', 'gives you wings']);
-  });
-
-  it('should support broken phrases', function(){
-    tokenizer('red bull "gives you wings')
-      .should.eql(['red', 'bull', '"gives', 'you', 'wings']);
-  });
-
-  it('should support broken phrases (2)', function(){
-    tokenizer('red bull gives you wings"')
-      .should.eql(['red', 'bull', 'gives', 'you', 'wings"']);
-  });
+describe( 'tokenizer', function()
+{
+	it( 'should support single word inputs', function() {
+		tokenizer( 'redbull' )
+			.should.jsonEql( ['redbull'] );
+	});
+	
+	it( 'should support multiple words', function() {
+		tokenizer( 'red bull' )
+			.should.jsonEql( ['red', 'bull'] );
+	});
+	
+	it( 'should handle empty queries', function() {
+		tokenizer( '' )
+			.should.jsonEql( [''] );
+		tokenizer( ' ' )
+			.should.jsonEql( [''] );
+	});
+	
+	it( 'should trim spaces', function() {
+		tokenizer( ' redbull ' )
+			.should.jsonEql( ['redbull'] );
+	});
+	
+	it( 'should support quoted phrases', function() {
+		var result = tokenizer( '"red bull"' );
+		result.should.jsonEql( ['red bull'] );
+		result[0].phrase.should.eql( true );
+		
+		result = tokenizer( "'red bull'" );
+		result.should.jsonEql( ['red bull'] );
+		result[0].phrase.should.eql( true );
+	});
+	
+	it( 'should not interpret apostrophes as single quoted phrases', function() {
+		tokenizer( "don't won't" )
+			.should.jsonEql( ["don't", "won't"] );
+	});
+	
+	it( 'should support multiple phrases', function() {
+		tokenizer( '"red bull" "gives you wings"' )
+			.should.jsonEql( ['red bull', 'gives you wings'] );
+	});
+	
+	it( 'should support single words and phrases', function() {
+		tokenizer( 'red bull "gives you wings"' )
+			.should.jsonEql( ['red', 'bull', 'gives you wings'] );
+	});
+	
+	it( 'should support broken phrases', function() {
+		tokenizer( 'red bull "gives you wings' )
+			.should.jsonEql( ['red', 'bull', '"gives', 'you', 'wings'] );
+		tokenizer( 'red bull gives you wings"' )
+			.should.jsonEql( ['red', 'bull', 'gives', 'you', 'wings"'] );
+	});
 });


### PR DESCRIPTION
Hi, I've added support for tagged terms (tag:term). I've also made the output more consistent, always making it return an array, and returning an empty array instead of an empty string, so I've bumped the version to 2.0.0.

Next will be OR support, but I needed this first.