### PR TITLE
Support exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A search query tokeniser inspired by Google.
 - Split a space-delimitered query string into an array of terms
 - Treat quoted terms as phrases
 - Support tagged terms (tag:term)
+- Detect excluded terms (-term)
 
 ## Examples
 
@@ -21,6 +22,9 @@ var result = console.log( tokenizer( '"red bull" "gives you wings"' ) );
 
 result = console.log( tokenizer( 'author:tolkien' ) );
 // [ { term: 'tolkien', tag: 'author' } ]
+
+result = console.log( tokenizer( '-car' ) );
+// [ { term: 'car', exclude: true } ]
 ```
 
 ## Installation
@@ -40,4 +44,4 @@ $ npm test
 
 ## License
 
-MIT © Tatsuya Oiwa, Dannii Willis
+MIT © Tatsuya Oiwa, Dannii Willis, James Anthony Bruno

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -6,13 +6,13 @@ function tokenize( input )
 	// Trim input
 	input = _.trim( input );
 	
-	var pattern = /(\w+:)?("[^"]*"|'[^']*'|[^\s]+)/g,
+	var pattern = /(\w+:|-)?("[^"]*"|'[^']*'|[^\s]+)/g,
 	results = [],
 	matched;
 	
 	while ( matched = pattern.exec( input ) )
 	{
-		var tag = matched[1],
+		var prefix = matched[1],
 		term = matched[2],
 		result = {};
 		
@@ -30,9 +30,16 @@ function tokenize( input )
 		
 		result.term = term;
 		
-		if ( tag )
+		if ( prefix )
 		{
-			result.tag = tag.slice( 0, -1 );
+			if ( prefix == '-' )
+			{
+				result.not = true;
+			} 
+			else
+			{
+				result.tag = prefix.slice( 0, -1 );
+			}
 		}
 		
 		results.push( result );

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -34,7 +34,7 @@ function tokenize( input )
 		{
 			if ( prefix == '-' )
 			{
-				result.not = true;
+				result.exclude = true;
 			} 
 			else
 			{

--- a/test/test.tokenizer.js
+++ b/test/test.tokenizer.js
@@ -105,4 +105,28 @@ describe( 'tokenizer', function()
 				tag: 'author',
 			} ] );
 	});
+
+	it( 'should support negation', function() {
+		tokenizer( '-redbull' )
+			.should.eql( [ {
+				term: 'redbull',
+				not: true
+			} ] );
+	});
+
+	it( 'should support negation of phrases', function() {
+		tokenizer( '-"red bull"' )
+			.should.eql( [ {
+				term: 'red bull',
+				phrase: true,
+				not: true
+			} ] );
+
+		tokenizer( "-'red bull'" )
+			.should.eql( [ {
+				term: 'red bull',
+				phrase: true,
+				not: true
+			} ] );
+	});
 });

--- a/test/test.tokenizer.js
+++ b/test/test.tokenizer.js
@@ -106,27 +106,27 @@ describe( 'tokenizer', function()
 			} ] );
 	});
 
-	it( 'should support negation', function() {
+	it( 'should support exclusion', function() {
 		tokenizer( '-redbull' )
 			.should.eql( [ {
 				term: 'redbull',
-				not: true
+				exclude: true
 			} ] );
 	});
 
-	it( 'should support negation of phrases', function() {
+	it( 'should support exclusion of phrases', function() {
 		tokenizer( '-"red bull"' )
 			.should.eql( [ {
 				term: 'red bull',
 				phrase: true,
-				not: true
+				exclude: true
 			} ] );
 
 		tokenizer( "-'red bull'" )
 			.should.eql( [ {
 				term: 'red bull',
 				phrase: true,
-				not: true
+				exclude: true
 			} ] );
 	});
 });


### PR DESCRIPTION
The Google search syntax supports negation/exclusion by adding a `-` in front of the term ([source](https://support.google.com/websearch/answer/2466433?hl=en)). For example, a Google search for `jaguars -car` will return results for jaguars that don't mention the car. This pull request adds this to your package by including the attribute "exclude". For example:

```js
[
  {
    term: "jaguars",
  },
  {
    term: "car",
    exclude: true
  }
]
```

This will also work with both single and double quotation phrases.

I added two tests for this: one for without phrases and one with (both single and double quotes). All tests pass.
