### PR TITLE
Only include the trim function from lodash.

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -1,10 +1,10 @@
-var _ = require( 'lodash' );
+var trim = require( 'lodash/trim' );
 
 function tokenize( input )
 {
 
 	// Trim input
-	input = _.trim( input );
+	input = trim( input );
 	
 	var pattern = /(\w+:)?("[^"]*"|'[^']*'|[^\s]+)/g,
 	results = [],
@@ -19,12 +19,12 @@ function tokenize( input )
 		// Remove quotes
 		if ( /^".+"$/.test( term ) )
 		{
-			term = _.trim( term, '" ' );
+			term = trim( term, '" ' );
 			result.phrase = true;
 		}
 		if ( /^'.+'$/.test( term ) )
 		{
-			term = _.trim( term, "' " );
+			term = trim( term, "' " );
 			result.phrase = true;
 		}
 		


### PR DESCRIPTION
Reduces file size when used with utilities such as Browserify since it doesn't need to load _all_ the functions within lodash. Passes all tests.